### PR TITLE
docs: Update CIFAR-100 README with Trial 17 evaluation results

### DIFF
--- a/examples/CIFAR100/README.md
+++ b/examples/CIFAR100/README.md
@@ -4,8 +4,8 @@ This directory contains the complete set of experiments for KTG (Knowledge Trans
 
 ### Highlights (TL;DR) — Focus on Node0 `resnet32`
 - **pre-train (test)**: 71.44%
-- **DML (test)**: 72.97% (+1.53pt vs pre-train)
-- **DCL (test)**: 73.49% (+2.05pt vs pre-train)
+- **DML (test)**: 73.55% (+2.11pt vs pre-train)
+- **DCL (test)**: 73.64% (+2.20pt vs pre-train)
 
 ### Table of Contents
 - Dataset and preprocessing
@@ -38,20 +38,20 @@ This directory contains the complete set of experiments for KTG (Knowledge Trans
 ### DCL search summary
 - Study: `dcl_3` (number of nodes = 3)
 - Log: `examples/CIFAR-100/optuna/dcl_3/optuna.log`
-- Best trial: **Trial 1**
-- Best score: **Top-1 72.31%** (estimated on `val`)
-- Trial outputs: `examples/CIFAR-100/runs/dcl_3/0001/`
+- Best trial: **Trial 17**
+- Best score: **Top-1 72.21%** (estimated on `val`)
+- Trial outputs: `examples/CIFAR-100/runs/dcl_3/0017/`
 - Number of trials: 100
 
-#### Best trial configuration (Trial 1)
-- Models (node0→2): `[resnet32, resnet110, wideresnet28_2]`
+#### Best trial configuration (Trial 17)
+- Models (node0→2): `[resnet32, resnet32, wideresnet28_2]`
 - Gate matrix (row = i node = receiver, column = j node = sender. Each cell controls transfer j→i)
 
 | i\j | 0 | 1 | 2 |
 |---|---|---|---|
-| 0 | PositiveLinearGate | ThroughGate | PositiveLinearGate |
-| 1 | PositiveLinearGate | NegativeLinearGate | NegativeLinearGate |
-| 2 | NegativeLinearGate | CutoffGate | NegativeLinearGate |
+| 0 | LinearGate | CorrectGate | ThroughGate |
+| 1 | CutoffGate | CutoffGate | CorrectGate |
+| 2 | CorrectGate | CorrectGate | CorrectGate |
 
 > Note: In the code, the outer loop is `i` (receiver) and the inner loop is `j` (sender) (`{i}_{j}_gate`).
 
@@ -59,29 +59,29 @@ This directory contains the complete set of experiments for KTG (Knowledge Trans
 
 #### dcl_test.py (retraining with the best trial)
 - Log: `examples/CIFAR-100/evaluation/runs/dcl_3/{trial:04}/{node}_{model}/`
-  - Example: `examples/CIFAR-100/evaluation/runs/dcl_3/0001/0_resnet32/`
+  - Example: `examples/CIFAR-100/evaluation/runs/dcl_3/0017/0_resnet32/`
 - Checkpoints: `examples/CIFAR-100/evaluation/checkpoint/dcl_3/{trial:04}/{node}_{model}/`
-  - Example: `examples/CIFAR-100/evaluation/checkpoint/dcl_3/0001/0_resnet32/`
+  - Example: `examples/CIFAR-100/evaluation/checkpoint/dcl_3/0017/0_resnet32/`
 
 | Node | Model | Best Top-1(%) | Best Epoch |
 |---|---|---:|---:|
-| 0 | resnet32  | 73.49 | 200 |
-| 1 | resnet110 | 75.43 | 199 |
-| 2 | wideresnet28_2 | 77.09 | 197 |
+| 0 | resnet32  | 73.64 | 195 |
+| 1 | resnet32 | 73.41 | 196 |
+| 2 | wideresnet28_2 | 76.50 | 199 |
 
 > Note: `dcl_test.py` reconstructs the graph with the best-trial configuration and evaluates on the `test` set.
 
 #### dml_test.py (all edges ThroughGate)
 - Log: `examples/CIFAR-100/evaluation/runs/dml_3/{trial:04}/{node}_{model}/`
-  - Example: `examples/CIFAR-100/evaluation/runs/dml_3/0001/0_resnet32/`
+  - Example: `examples/CIFAR-100/evaluation/runs/dml_3/0017/0_resnet32/`
 - Checkpoints: `examples/CIFAR-100/evaluation/checkpoint/dml_3/{trial:04}/{node}_{model}/`
-  - Example: `examples/CIFAR-100/evaluation/checkpoint/dml_3/0001/0_resnet32/`
+  - Example: `examples/CIFAR-100/evaluation/checkpoint/dml_3/0017/0_resnet32/`
 
 | Node | Model | Best Top-1(%) | Best Epoch |
 |---|---|---:|---:|
-| 0 | resnet32  | 72.97 | 199 |
-| 1 | resnet110 | 76.80 | 199 |
-| 2 | wideresnet28_2 | 77.02 | 197 |
+| 0 | resnet32  | 73.55 | 196 |
+| 1 | resnet32 | 73.85 | 197 |
+| 2 | wideresnet28_2 | 76.79 | 197 |
 
 > Note: This evaluates the DML configuration where all edges are fixed to `ThroughGate`.
 
@@ -116,7 +116,7 @@ uv run dcl_train.py --num-nodes 3 --n_trials 100 \
 3) Retraining + evaluation with the best trial (test-operation mode)
 ```bash
 cd examples/CIFAR-100/evaluation
-uv run dcl_test.py --num-nodes 3 --trial 1
+uv run dcl_test.py --num-nodes 3 --trial 17
 # If omitted, the study's best_trial is used by default
 ```
 


### PR DESCRIPTION
Update README.md to reflect the latest evaluation results from Trial 17:
- Update DCL/DML test results for all nodes
- Update best trial from Trial 1 to Trial 17
- Update model configuration (Node 1: resnet110 -> resnet32)
- Update gate matrix with Trial 17 configuration
- Update highlights showing improved results (DCL: 73.64%, DML: 73.55%)
- Update pre-train results to show only evaluated models

🤖 Generated with [Claude Code](https://claude.com/claude-code)